### PR TITLE
Add Time2Vec and Time2VecMult scalers

### DIFF
--- a/ptls/nn/trx_encoder/scalers.py
+++ b/ptls/nn/trx_encoder/scalers.py
@@ -184,6 +184,79 @@ class PLE_MLP(IdentityScaler):
         return self.mlp_output_size
 
 
+class Time2VecMult(IdentityScaler):
+    """
+    Multidimensional time encoding.
+    Proposed in paper "Incorporating Time in Sequential Recommendation Models" as "Projection-based approach".
+    Input tensor must contain Unix timestamps in seconds.
+    Timestamps are converted into numerical features and encoded using a linear layer and a cosine function.
+    """
+
+    def __init__(self, embeddings_size: int) -> None:
+        """
+        Class initialization.
+
+        Args:
+            embeddings_size (int): Desired size of time embeddings.
+        """
+
+        super().__init__()
+
+        self.embeddings_size = embeddings_size
+
+        self.fc = nn.Linear(4, self.embeddings_size)
+
+    def forward(self, timestamps: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass.
+
+        Args:
+            timestamps (torch.Tensor): Tensor containing Unix timestamps in seconds.
+
+        Returns:
+            torch.Tensor: Tensor with resulting time embeddings.
+        """
+
+        # Calculating the numbers of hours and days passed since 01-01-1970
+        total_hours = timestamps.float() / 3600.0
+        total_days = total_hours / 24.0
+
+        # 1. Normalized hour of the day [0, 1]
+        hour_of_day = torch.fmod(total_hours, 24.0) / 23.0
+
+        # 2. Normalized day of the week [0, 1] (0 - Mon, 1 - Sun)
+        day_of_week = torch.fmod((total_days.long() + 3), 7).float() / 6.0
+
+        # 3. Normalized week of the month [0, 1]
+        # (approximation)
+        day_of_month_approx = torch.fmod(total_days, 30.44)
+        week_of_month = (day_of_month_approx / 7.0).clamp(0.0, 4.0) / 4.0
+
+        # 4. Normalized month of the year [0, 1] (0 - Jan, 1 - Dec)
+        # (approximation)
+        month_of_year = torch.fmod(total_days / 30.44, 12.0) / 11.0
+
+        # Staking 4 tensors with timestamp features into one
+        timestamp_features = torch.stack([
+            hour_of_day,
+            day_of_week,
+            week_of_month,
+            month_of_year
+        ], dim=-1)
+
+        # Applying a linear layer and a cosine function
+        return torch.cos(self.fc(timestamp_features))
+
+    @property
+    def output_size(self) -> int:
+        """
+        Returns:
+            int: The last dimension of the output tensor.
+        """
+
+        return self.embeddings_size
+
+
 def scaler_by_name(name):
     scaler = {
         'identity': IdentityScaler,

--- a/ptls/nn/trx_encoder/scalers.py
+++ b/ptls/nn/trx_encoder/scalers.py
@@ -291,25 +291,24 @@ class Time2VecMult(IdentityScaler):
         total_days = total_hours / 24.0
 
         # 1. Normalized hour of the day [0, 1]
-        hour_of_day = torch.fmod(total_hours, 24.0) / 23.0
+        hour_of_day = torch.fmod(total_hours, 24.0) / 24.0
 
         # 2. Normalized day of the week [0, 1] (0 - Mon, 1 - Sun)
-        day_of_week = torch.fmod((total_days.long() + 3), 7).float() / 6.0
+        day_of_week = torch.fmod(total_days + 3.0, 7.0) / 7.0
 
-        # 3. Normalized week of the month [0, 1]
+        # 3. Normalized day of the month [0, 1]
         # (approximation)
-        day_of_month_approx = torch.fmod(total_days, 30.44)
-        week_of_month = (day_of_month_approx / 7.0).clamp(0.0, 4.0) / 4.0
+        day_of_month = torch.fmod(total_days, 30.44) / 30.44
 
         # 4. Normalized month of the year [0, 1] (0 - Jan, 1 - Dec)
         # (approximation)
-        month_of_year = torch.fmod(total_days / 30.44, 12.0) / 11.0
+        month_of_year = torch.fmod(total_days / 30.44, 12.0) / 12.0
 
         # Staking 4 tensors with timestamp features into one
         timestamp_features = torch.stack([
             hour_of_day,
             day_of_week,
-            week_of_month,
+            day_of_month,
             month_of_year
         ], dim=-1)
 

--- a/ptls_tests/test_nn/test_trx_encoder/test_scalers.py
+++ b/ptls_tests/test_nn/test_trx_encoder/test_scalers.py
@@ -11,6 +11,7 @@ from ptls.nn.trx_encoder.scalers import (
     Periodic,
     PeriodicMLP,
     PoissonScaler,
+    Time2Vec,
     Time2VecMult,
 )
 
@@ -289,6 +290,22 @@ def test_exp_scaler():
     assert z.payload.shape == (B, T, 1)
     assert trx_encoder.output_size == 1
     assert torch.all(z.payload > 0)
+
+
+def test_time2vec():
+    B, T = 5, 20
+    embeddings_size = 16
+    scaler = Time2Vec(embeddings_size=embeddings_size)
+    trx_encoder = TrxEncoder(numeric_values={'event_time': scaler})
+    x = PaddedBatch(
+        payload={
+            'event_time': torch.randint(0, 365, (B, T)),
+        },
+        length=torch.randint(10, 20, (B,))
+    )
+    z = trx_encoder(x)
+    assert z.payload.shape == (B, T, embeddings_size + 1)
+    assert trx_encoder.output_size == embeddings_size + 1
 
 
 def test_time2vec_mult():

--- a/ptls_tests/test_nn/test_trx_encoder/test_scalers.py
+++ b/ptls_tests/test_nn/test_trx_encoder/test_scalers.py
@@ -19,7 +19,7 @@ from ptls.nn.trx_encoder.scalers import (
 def test_periodic():
     B, T = 5, 20
     num_periods = 4
-    scaler = Periodic(num_periods = num_periods, param_dist_sigma = 3)
+    scaler = Periodic(num_periods=num_periods, param_dist_sigma=3)
     trx_encoder = TrxEncoder(
         numeric_values={'amount': scaler},
     )
@@ -30,14 +30,14 @@ def test_periodic():
         length=torch.randint(10, 20, (B,)),
     )
     z = trx_encoder(x)
-    assert z.payload.shape == (5, 20, 2 * num_periods)  # B, T, H
+    assert z.payload.shape == (B, T, 2 * num_periods)  # B, T, H
     assert trx_encoder.output_size == 2 * num_periods
 
 
 def test_periodic_mlp():
     B, T = 5, 20
     num_periods = 4
-    scaler = PeriodicMLP(num_periods = num_periods, param_dist_sigma = 3)
+    scaler = PeriodicMLP(num_periods=num_periods, param_dist_sigma=3)
     trx_encoder = TrxEncoder(
         numeric_values={'amount': scaler},
     )
@@ -48,7 +48,7 @@ def test_periodic_mlp():
         length=torch.randint(10, 20, (B,)),
     )
     z = trx_encoder(x)
-    assert z.payload.shape == (5, 20, 2 * num_periods)  # B, T, H
+    assert z.payload.shape == (B, T, 2 * num_periods)  # B, T, H
     assert trx_encoder.output_size == 2 * num_periods
 
 
@@ -56,7 +56,7 @@ def test_periodic_mlp2():
     B, T = 5, 20
     num_periods = 4
     mlp_output_size = 32
-    scaler = PeriodicMLP(num_periods = num_periods, param_dist_sigma = 3, mlp_output_size = mlp_output_size)
+    scaler = PeriodicMLP(num_periods=num_periods, param_dist_sigma=3, mlp_output_size=mlp_output_size)
     trx_encoder = TrxEncoder(
         numeric_values={'amount': scaler},
     )
@@ -67,14 +67,14 @@ def test_periodic_mlp2():
         length=torch.randint(10, 20, (B,)),
     )
     z = trx_encoder(x)
-    assert z.payload.shape == (5, 20, mlp_output_size)  # B, T, H
+    assert z.payload.shape == (B, T, mlp_output_size)  # B, T, H
     assert trx_encoder.output_size == mlp_output_size
 
 
 def test_ple():
     B, T = 5, 20
     bins = [-1, 0, 1]
-    scaler = PLE(bins = bins)
+    scaler = PLE(bins=bins)
     trx_encoder = TrxEncoder(
         numeric_values={'amount': scaler},
     )
@@ -85,14 +85,13 @@ def test_ple():
         length=torch.randint(10, 20, (B,)),
     )
     z = trx_encoder(x)
-    assert z.payload.shape == (5, 20, len(bins) - 1)  # B, T, H
+    assert z.payload.shape == (B, T, len(bins) - 1)  # B, T, H
     assert trx_encoder.output_size == len(bins) - 1
 
 
 def test_ple2():
-    B, T = 1, 20
     bins = [-1, 0, 1]
-    scaler = PLE(bins = bins)
+    scaler = PLE(bins=bins)
     trx_encoder = TrxEncoder(
         numeric_values={'amount': scaler},
         use_batch_norm=False,
@@ -119,7 +118,7 @@ def test_ple2():
 def test_ple_mlp():
     B, T = 5, 20
     bins = [-1, 0, 1]
-    scaler = PLE_MLP(bins = bins)
+    scaler = PLE_MLP(bins=bins)
     trx_encoder = TrxEncoder(
         numeric_values={'amount': scaler},
     )
@@ -130,7 +129,7 @@ def test_ple_mlp():
         length=torch.randint(10, 20, (B,)),
     )
     z = trx_encoder(x)
-    assert z.payload.shape == (5, 20, len(bins) - 1)  # B, T, H
+    assert z.payload.shape == (B, T, len(bins) - 1)  # B, T, H
     assert trx_encoder.output_size == len(bins) - 1
 
 
@@ -138,7 +137,7 @@ def test_ple_mlp2():
     B, T = 5, 20
     bins = [-1, 0, 1]
     mlp_output_size = 64
-    scaler = PLE_MLP(bins = bins, mlp_output_size = mlp_output_size)
+    scaler = PLE_MLP(bins=bins, mlp_output_size=mlp_output_size)
     trx_encoder = TrxEncoder(
         numeric_values={'amount': scaler},
     )
@@ -149,7 +148,7 @@ def test_ple_mlp2():
         length=torch.randint(10, 20, (B,)),
     )
     z = trx_encoder(x)
-    assert z.payload.shape == (5, 20, mlp_output_size)  # B, T, H
+    assert z.payload.shape == (B, T, mlp_output_size)  # B, T, H
     assert trx_encoder.output_size == mlp_output_size
 
 
@@ -223,7 +222,7 @@ def test_year_scaler():
 def test_num_to_vector():
     B, T = 5, 20
     embeddings_size = 32
-    scaler = NumToVector(embeddings_size)   
+    scaler = NumToVector(embeddings_size)
     trx_encoder = TrxEncoder(
         numeric_values={'amount': scaler},
     )


### PR DESCRIPTION
В рамках данного Pull Request сделано следующее:
- Добавлены подходы для кодирования времени транзакций в виде скейлеров:
  - **Time2Vec** из статьи _"Time2Vec: Learning a Vector Representation of Time"_;
  - **Time2VecMult** из статьи _"Incorporating Time in Sequential Recommendation Models"_;
- Добавлены тесты для этих скейлеров;
- Проведён рефакторинг файлов `ptls/nn/trx_encoder/scalers.py` и `ptls_tests/test_nn/test_trx_encoder/test_scalers.py` для лучшего соответствия стандарту PEP8 (могу откатить, если это не требуется).

Из возможных замечаний стоит отметить то, что классический **Time2Vec** может работать с временем любого типа (абсолютное, относительное, с прошлой транзакции) и в любых единицах измерения (секунды, часы, дни), но всё же он лучше работает, если входные данные нормализованы. Пока что я не добавил нормализацию внутрь класса **Time2Vec**, потому что не уверен, как её лучше реализовать.